### PR TITLE
feat(#193): Deploy SageWorks Sandbox using Python CDK

### DIFF
--- a/aws_setup/sageworks_sandbox/README.md
+++ b/aws_setup/sageworks_sandbox/README.md
@@ -1,7 +1,7 @@
 # SageWorks Sandbox AWS Deployment
 
 To run/deploy the SageWorks AWS Sandbox you'll need install a couple of Python packages
-either in a Python VirtualENV of your choice (PyENV is good) or any Python3 will do
+either in a Python VirtualENV of your choice (PyENV is good) or any Python3 will do. You'll also need to use a newer version of node such as node v19.6
 
 ```
 $ pip install -r requirements.txt

--- a/aws_setup/sageworks_sandbox/app.py
+++ b/aws_setup/sageworks_sandbox/app.py
@@ -3,13 +3,22 @@
 import aws_cdk as cdk
 
 from sageworks_sandbox.sageworks_sandbox_stack import SageworksStack
+from sageworks.utils.sageworks_config import SageWorksConfig
 
+sageworks_config: SageWorksConfig = SageWorksConfig()
 
 app = cdk.App()
+
+s3_bucket_name = sageworks_config.get_config_value("SAGEWORKS_AWS", "S3_BUCKET_NAME")
+sageworks_role_name = sageworks_config.get_config_value(
+    "SAGEWORKS_AWS", "SAGEWORKS_ROLE_NAME"
+)
+
 sandbox_stack = SageworksStack(
     app,
     "SageworksSandbox",
-    company_name="TODO-Company-Name"
+    s3_bucket_name=s3_bucket_name,
+    sageworks_role_name=sageworks_role_name
     # If you don't specify 'env', this stack will be environment-agnostic.
     # Account/Region-dependent features and context lookups will not work,
     # but a single synthesized template can be deployed anywhere.

--- a/aws_setup/sageworks_sandbox/app.py
+++ b/aws_setup/sageworks_sandbox/app.py
@@ -1,28 +1,25 @@
 #!/usr/bin/env python3
-import os
 
 import aws_cdk as cdk
 
-from sageworks_sandbox.sageworks_sandbox_stack import SageworksSandboxStack
+from sageworks_sandbox.sageworks_sandbox_stack import SageworksStack
 
 
 app = cdk.App()
-SageworksSandboxStack(app, "SageworksSandbox",
+sandbox_stack = SageworksStack(
+    app,
+    "SageworksSandbox",
+    company_name="TODO-Company-Name"
     # If you don't specify 'env', this stack will be environment-agnostic.
     # Account/Region-dependent features and context lookups will not work,
     # but a single synthesized template can be deployed anywhere.
-
     # Uncomment the next line to specialize this stack for the AWS Account
     # and Region that are implied by the current CLI configuration.
-
-    #env=cdk.Environment(account=os.getenv('CDK_DEFAULT_ACCOUNT'), region=os.getenv('CDK_DEFAULT_REGION')),
-
+    # env=cdk.Environment(account=os.getenv('CDK_DEFAULT_ACCOUNT'), region=os.getenv('CDK_DEFAULT_REGION')),
     # Uncomment the next line if you know exactly what Account and Region you
     # want to deploy the stack to. */
-
-    #env=cdk.Environment(account='123456789012', region='us-east-1'),
-
+    # env=cdk.Environment(account='123456789012', region='us-east-1'),
     # For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
-    )
+)
 
 app.synth()

--- a/aws_setup/sageworks_sandbox/sageworks_sandbox/sageworks_sandbox_stack.py
+++ b/aws_setup/sageworks_sandbox/sageworks_sandbox/sageworks_sandbox_stack.py
@@ -2,18 +2,50 @@ from aws_cdk import (
     # Duration,
     Stack,
     # aws_sqs as sqs,
+    aws_iam as iam,
+    aws_s3 as s3,
 )
 from constructs import Construct
 
-class SageworksSandboxStack(Stack):
 
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+class SageworksStack(Stack):
+    def __init__(
+        self, scope: Construct, construct_id: str, company_name: str, **kwargs
+    ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        # The code that defines your stack goes here
+        self.sageworks_execution_role = self.create_execution_role(
+            "SageWorksExecutionRole"
+        )
+        self.sageworks_execution_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["s3:*", "s3-object-lambda:*"],
+                resources=[
+                    "arn:aws:s3:::aws-athena-query-results",
+                    "arn:aws:s3:::*sageworks-artifacts*",
+                ],
+            )
+        )
+        self.add_artifact_bucket(company_name)
 
-        # example resource
-        # queue = sqs.Queue(
-        #     self, "SageworksSandboxQueue",
-        #     visibility_timeout=Duration.seconds(300),
-        # )
+        # TODO: Use this if we need a duplicate role
+        # self.glue_service_role = self.create_execution_role("AWSGlueServiceRole-Sageworks")
+
+    def create_execution_role(self, role_name) -> iam.Role:
+        return iam.Role(
+            self,
+            id=role_name,
+            assumed_by=iam.AnyPrincipal(),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name("AWSGlueServiceRole"),
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "AmazonSageMakerFullAccess"
+                ),
+            ],
+        )
+
+    def add_artifact_bucket(self, company_name) -> None:
+        self.artifact_bucket = s3.Bucket(
+            self,
+            f"com.{company_name}-sageworks-artifacts",
+        )

--- a/aws_setup/sageworks_sandbox/tests/unit/test_sageworks_sandbox_stack.py
+++ b/aws_setup/sageworks_sandbox/tests/unit/test_sageworks_sandbox_stack.py
@@ -1,15 +1,17 @@
 import aws_cdk as core
-import aws_cdk.assertions as assertions
+from aws_cdk.assertions import Template
 
-from sageworks_sandbox.sageworks_sandbox_stack import SageworksSandboxStack
+from sageworks_sandbox.sageworks_sandbox_stack import SageworksStack
+
 
 # example tests. To run these tests, uncomment this file along with the example
 # resource in sageworks_sandbox/sageworks_sandbox_stack.py
 def test_sqs_queue_created():
     app = core.App()
-    stack = SageworksSandboxStack(app, "sageworks-sandbox")
-    template = assertions.Template.from_stack(stack)
+    stack = SageworksStack(app, "sageworks-sandbox", "my-test-company-name")
+    template = Template.from_stack(stack)
 
-#     template.has_resource_properties("AWS::SQS::Queue", {
-#         "VisibilityTimeout": 300
-#     })
+    # TODO: Check for specific properties
+    template.resource_count_is("AWS::IAM::Role", 1)
+    template.resource_count_is("AWS::IAM::Policy", 1)
+    template.resource_count_is("AWS::S3::Bucket", 1)

--- a/aws_setup/sageworks_sandbox/tests/unit/test_sageworks_sandbox_stack.py
+++ b/aws_setup/sageworks_sandbox/tests/unit/test_sageworks_sandbox_stack.py
@@ -8,7 +8,12 @@ from sageworks_sandbox.sageworks_sandbox_stack import SageworksStack
 # resource in sageworks_sandbox/sageworks_sandbox_stack.py
 def test_sqs_queue_created():
     app = core.App()
-    stack = SageworksStack(app, "sageworks-sandbox", "my-test-company-name")
+    stack = SageworksStack(
+        app,
+        "sageworks-sandbox",
+        "test-scp-sageworks-artifacts",
+        "SageWorks-ExecutionRole",
+    )
     template = Template.from_stack(stack)
 
     # TODO: Check for specific properties

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sagemaker >= 2.143
 dash >= 2.8
 dash-bootstrap-components
 dash-bootstrap-templates
+aws-cdk-lib >= 2.76.0


### PR DESCRIPTION
Addresses [Issue #193](https://github.com/SuperCowPowers/sageworks/issues/193)

Creates a simple sandbox stack using Python AWS CDK code that contains:
- The SageworksExecutionRole
- The Sageworks S3 Bucket

Both of these grab the names from the `sageworks_config.ini` and can be deployed using `cdk deploy --profile [your_profile]`. The bucket names are global, so it's important to note that whoever is deploying this will have to make sure they're unique. 