### PR TITLE
1309 bugfix

### DIFF
--- a/src/sageworks/artifacts/endpoints/endpoint.py
+++ b/src/sageworks/artifacts/endpoints/endpoint.py
@@ -458,7 +458,7 @@ class Endpoint(Artifact):
         self.details(recompute=True)
 
     @staticmethod
-    def shap_values(model, X: pd.DataFrame) -> pd.DataFrame:
+    def shap_values(model, X: pd.DataFrame) -> np.array:
         """Compute the SHAP values for this Model
         Args:
             model (Model): Model object

--- a/src/sageworks/artifacts/endpoints/endpoint.py
+++ b/src/sageworks/artifacts/endpoints/endpoint.py
@@ -436,7 +436,7 @@ class Endpoint(Artifact):
             
                 # Write shap vals to S3 Model Inference Folder
                 self.log.debug(f"Writing SHAP values to {self.model_inference_path}/inference_shap_values.csv")
-                wr.s3.to_csv(shap_vals, f"{self.model_inference_path}/inference_shap_values_class_{i}.csv", index=False)
+                wr.s3.to_csv(df_shap, f"{self.model_inference_path}/inference_shap_values_class_{i}.csv", index=False)
 
         # Single shap vals CSV for regressors
         if model_type == ModelType.REGRESSOR.value:

--- a/src/sageworks/artifacts/models/model.py
+++ b/src/sageworks/artifacts/models/model.py
@@ -201,7 +201,7 @@ class Model(Artifact):
         """
 
         # Multiple CSV if classifier
-        if self.model_type == ModelType.CLASSIFIER.value:
+        if self.model_type == ModelType.CLASSIFIER:
             
             # CSVs for shap values are indexed by prediction class
             # Because we don't know how many classes there are, we need to search through
@@ -210,7 +210,7 @@ class Model(Artifact):
             return [self._pull_s3_model_artifacts(f, embedded_index=False) for f in s3_paths if "inference_shap_values" in f]
         
         # One CSV if regressor
-        if self.model_type == ModelType.REGRESSOR.value:
+        if self.model_type == ModelType.REGRESSOR:
 
             s3_path = f"{self.model_inference_path}/inference_shap_values.csv"
             return self._pull_s3_model_artifacts(s3_path, embedded_index=False)


### PR DESCRIPTION
While regression models only have a single shapley value dataframe, classifier models produce a shapley value dataframe for every prediction class.
This branch contains logic to accommodate this new data structure.

Also fixed a bug which occurs when there are multiple joblib file types. If there are multiple joblib file types in the artifact directory the model artifact extraction method would pull the first one. Now, the logic iterates through each joblib file, and has an isinstance() type check which verifies that the joblib file produces an XGBModel class. This will need to be extended for other models object types; the optimal solution is probably to use the base sklearn model object class, which I believe is inherited by all sklearn and xgboost models.

