### PR TITLE
dag templates

### DIFF
--- a/src/sageworks/web_components/experiments/assets/custom_styling.css
+++ b/src/sageworks/web_components/experiments/assets/custom_styling.css
@@ -1,0 +1,28 @@
+
+/*.ag-theme-custom {*/
+/*    --ag-header-height: 30px !important;*/
+/*}*/
+
+.ag-theme-custom .ag-header {
+    background: linear-gradient(rgba(255, 255, 255, 0.5), rgb(115, 190, 115));
+}
+.ag-theme-custom-dark .ag-header {
+    background: linear-gradient(rgb(60, 100, 60), rgba(0, 0, 0, 0.5));
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/sageworks/web_components/experiments/assets/dashAgGridComponentFunctions.js
+++ b/src/sageworks/web_components/experiments/assets/dashAgGridComponentFunctions.js
@@ -1,0 +1,9 @@
+var dagcomponentfuncs = (window.dashAgGridComponentFunctions = window.dashAgGridComponentFunctions || {});
+
+dagcomponentfuncs.Link = function (props) {
+    return React.createElement(
+        'a',
+        {href:  props.value},
+        props.value
+    );
+};


### PR DESCRIPTION
# Pull Request Checklist

Thank you for contributing to the SuperCowPowers SageWorks project. Please make sure you've completed the following tasks before submitting your pull request:

#### GENERAL
- [x] I've read the [CONTRIBUTING](https://github.com/SuperCowPowers/sageworks/blob/main/CONTRIBUTING.md) document.
- [x] I've merged 'main' into my PR branch (like today's main)

#### TESTING (run 'tox' for local testing)
- [  ] I've added tests to cover my changes
- [  ] black/flake8 linter tests passed
- [  ] 100% of the tests passed

#### UI (Web Interface/Components)
- [  ] I've run sageworks/applications/aws_dashboard/dashboard
- [  ] I've tested the UI and scanned the log output for any issues

#### DOCUMENTATION
- [  ] I've updated the documentation accordingly

#### REVIEW 
- [x] I've added (or will add) a reviewer to the PR
- [x] I'll address any comments/request from reviewer
- [x] I will delete the branch after the PR is merged 

#### Notes
An SCP Developer/reviewer may make direct changes to your branch. A follow up issue might be created or asked for. Branches are empheral, they should/will be deleted after the PR is merged. Do not reuse an old branch, if a change needs to be made pull a new branch off of main.

---

## Description of Changes

Add a simple exemple to showcase Dash AG Grid built-in light/dark templates:

- move `sageworks\ui_testing\table_comparison.py`
  to `sageworks\src\sageworks\web_components\experiments\table_comparison.py`, I think no need to create a new folder.
- add all AG Grid built-in themes
- with a custom header background using gradient for light and dark theme  
  Note: I set a fixed header height to 30px, but commented the prop in the .css to show the height of the built-in
  themes
- custom text formater:
    - **Name**: in uppercase
    - **Salary**: add ',' as thousands separator
    - **Bonus**: use '.' as decimal separator and use 2 significant digits
    - **Company**: custom cell renderer to use hyperlinks  
      Note: it is possible to use markdown like with the current DataTable, but it's safer to create the <a> element
      ourselves (see https://dash.plotly.com/dash-ag-grid/markdown-component)

Those text formatters are made for this particular dataset, not really reusable, but it is possible to do better 👍

