### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SuperCowPowers/workbench/security/code-scanning/11](https://github.com/SuperCowPowers/workbench/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required for the workflow. Since the workflow involves deploying to GitHub Pages, it requires `contents: write` to push the built site to the repository. All other permissions will be omitted to minimize access.

The `permissions` block will be added at the root of the workflow, applying to all jobs within the workflow. This ensures that the `GITHUB_TOKEN` used in the workflow has only the necessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
